### PR TITLE
Collect Flow directly instead of mapping it into State

### DIFF
--- a/src/main/kotlin/midi/MidiSource.kt
+++ b/src/main/kotlin/midi/MidiSource.kt
@@ -47,22 +47,6 @@ class MidiSource(private val flow: MutableSharedFlow<MidiMessage>) : Receiver {
 
     override fun close() {}
 
-    val scope = CoroutineScope(Dispatchers.Default)
-
-//    fun playFlow() {
-//        scope.launch {
-//            flow.collect {
-//                val timestamp = System.nanoTime() / 1000//000
-//                println("Our timestamp is $timestamp")
-//                
-//                //synthesizer?.send(it, timestamp)
-//                send(it, timestamp)
-//            }
-//        }
-//    }
-    // 2081781244
-    // 2081776824284
-
     override fun send(message: MidiMessage, timeStamp: Long) {
         val status = message.getStatus()
 


### PR DESCRIPTION
Using `flow.collectAsState` conflated quickly arriving values from the `flow`, while running `collect{}` on it instead will actually make use of the buffer and process all incoming values